### PR TITLE
build: Dockerfile 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:17
+
+WORKDIR /app
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "./app.jar"]


### PR DESCRIPTION
도커 이미지 빌드 전에 gradle build를 먼저 해야한다.

See Also:
- https://spring.io/guides/gs/spring-boot-docker/

---
Close #12