### PR TITLE
refactor(remove): Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM openjdk:17
-
-WORKDIR /app
-
-ARG JAR_FILE=build/libs/*.jar
-
-COPY ${JAR_FILE} app.jar
-
-ENTRYPOINT ["java", "-jar", "./app.jar"]


### PR DESCRIPTION
CI/CD를 구축하면서 docker image를 ./gradlew bootImageBuild로 만들고 있으므로 Dockerfile이 더이상 필요하지 않음

---
Close #36