### PR TITLE
refactor(ci): gradle과 docker 분리

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+      - name: Gradle 권한 부여
+        run: |
+          chmod +x ./gradlew
+      - name: Gradle 초기화 및 빌드
+        run: |
+          ./gradlew clean 
+          ./gradlew build --exclude-task test --info
+      - name: Gradle 테스트
+        run: |
+          ./gradlew test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,36 +1,12 @@
-name: ci
+name: deploy
 
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
-  gradle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'corretto'
-      - name: Gradle 권한 부여
-        run: |
-          chmod +x ./gradlew
-      - name: Gradle 초기화 및 빌드
-        run: |
-          ./gradlew clean 
-          ./gradlew build --exclude-task test --info
-      - name: Gradle 테스트
-        run: |
-          ./gradlew test
-
   docker:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    needs: gradle
     steps:
       - uses: actions/checkout@v3
       - name: ECR 로그인


### PR DESCRIPTION
주요 변경사항
- gradle build 및 test는 main 브랜치에 pull request시에만 작동
- docker 이미지 build 및 push는 main 브랜치에 push시에만 작동

그 외
- ci -> build 이름 변경
- docker관련 설정은 deploy.yml으로 이동

---
Close #35