### PR TITLE
fix: google oauth2 client 정보 환경변수로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,6 @@ spring:
   h2:
     console:
       enabled: true
-  profiles:
-    include: oauth
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;
     driver-class-name: org.h2.Driver
@@ -16,3 +14,12 @@ spring:
       ddl-auto: none
   flyway:
     enabled: true # 생략 가능하나 직관적 명시를 위해 추가
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            scope: profile, email
+            client-id: ${GOOGLE_OAUTH2_CLIENT_ID}
+            client-secret: ${GOOGLE_OAUTH2_CLIENT_SECRET}

--- a/src/main/resources/example.application-oauth.yml
+++ b/src/main/resources/example.application-oauth.yml
@@ -1,9 +1,0 @@
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            scope: profile, email
-            client-id:
-            client-secret:


### PR DESCRIPTION
ci에서 dockerfile 빌드 시, git에 등록되지 않은 application-oauth.yml
때문에 배포 시 문제가 발생하여 이를 환경변수로 등록함

Close #69