### PR TITLE
feat: 템플릿 컴포넌트 및 대시보드 페이지 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
+        "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.3",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -2172,6 +2173,31 @@
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
+      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -23036,6 +23062,14 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.8.1",
         "react-is": "^17.0.2"
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
+      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "@mui/material": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
+    "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,14 +2,7 @@ import React from 'react'
 
 import {BrowserRouter, Route, Routes} from "react-router-dom";
 import LoginPage from "./pages/LoginPage";
-
-function DashBoardPage() {
-  return <>
-    <div>
-      ToDo: 개발 예정...
-    </div>
-  </>;
-}
+import DashBoardPage from "./pages/DashBoardPage";
 
 export default function App() {
   return (

--- a/frontend/src/components/containers/DashBoardContainer.jsx
+++ b/frontend/src/components/containers/DashBoardContainer.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import Paperbase from "../presentational/dashboard/Paperbase";
+
+export default function DashBoardContainer() {
+  return (
+    <Paperbase page="dashboard"/>
+  )
+}

--- a/frontend/src/components/presentational/dashboard/Content.jsx
+++ b/frontend/src/components/presentational/dashboard/Content.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import {Alert} from "@mui/material";
+
+export default function Content() {
+  return (
+    <Paper sx={{maxWidth: 936, margin: 'auto', overflow: 'hidden'}}>
+      <Alert severity="info">개발 예정</Alert>
+    </Paper>
+  );
+}

--- a/frontend/src/components/presentational/dashboard/Header.jsx
+++ b/frontend/src/components/presentational/dashboard/Header.jsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import AppBar from '@mui/material/AppBar';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+
+function Header(props) {
+  return (
+    <React.Fragment>
+      <AppBar color="primary" position="sticky" elevation={0}>
+        <Toolbar>
+          <Grid container spacing={1} alignItems="center">
+
+            <Grid item>
+              <Typography color="inherit">
+                {props.page}
+              </Typography>
+            </Grid>
+            <Grid sx={{display: {sm: 'none', xs: 'block'}}} item>
+              <IconButton
+                color="inherit"
+                aria-label="open drawer"
+                edge="start"
+              >
+                <MenuIcon/>
+              </IconButton>
+            </Grid>
+            <Grid item xs/>
+
+            {/*<Grid item>*/}
+            {/*  <Typography color="inherit">*/}
+            {/*    박주영*/}
+            {/*  </Typography>*/}
+            {/*</Grid>*/}
+            {/*<Grid item>*/}
+            {/*  <IconButton color="inherit" sx={{p: 0.5}}>*/}
+            {/*    <Avatar src="/static/images/avatar/1.jpg" alt="My Avatar"/>*/}
+            {/*  </IconButton>*/}
+            {/*</Grid>*/}
+          </Grid>
+        </Toolbar>
+      </AppBar>
+      <AppBar
+        component="div"
+        color="primary"
+        position="static"
+        elevation={0}
+        sx={{zIndex: 0}}
+      >
+      </AppBar>
+      <AppBar component="div" position="static" elevation={0} sx={{zIndex: 0}}>
+        <Tabs value={0} textColor="inherit">
+          <Tab label="메인"/>
+        </Tabs>
+      </AppBar>
+    </React.Fragment>
+  );
+}
+
+Header.propTypes = {
+  onDrawerToggle: PropTypes.func.isRequired,
+};
+
+export default Header;

--- a/frontend/src/components/presentational/dashboard/Navigator.jsx
+++ b/frontend/src/components/presentational/dashboard/Navigator.jsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import Box from '@mui/material/Box';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import HomeIcon from '@mui/icons-material/Home';
+import DnsRoundedIcon from '@mui/icons-material/DnsRounded';
+import PersonIcon from '@mui/icons-material/Person';
+
+const categories = [
+  {
+    id: '메인',
+    children: [
+      {id: '데이터', icon: <DnsRoundedIcon/>},
+    ],
+  },
+  {
+    id: '기타',
+    children: [
+      {id: '유저', icon: <PersonIcon/>},
+    ],
+  },
+];
+
+const item = {
+  py: '2px',
+  px: 3,
+  color: 'rgba(255, 255, 255, 0.7)',
+  '&:hover, &:focus': {
+    bgcolor: 'rgba(255, 255, 255, 0.08)',
+  },
+};
+
+const itemCategory = {
+  boxShadow: '0 -1px 0 rgb(255,255,255,0.1) inset',
+  py: 1.5,
+  px: 3,
+};
+
+export default function Navigator(props) {
+  const {...other} = props;
+
+  return (
+    <Drawer variant="permanent" {...other}>
+      <List disablePadding>
+        <ListItem sx={{...item, ...itemCategory, fontSize: 22, color: '#fff'}}>
+          AutoML
+        </ListItem>
+        <ListItem sx={{...item, ...itemCategory}}>
+          <ListItemIcon>
+            <HomeIcon/>
+          </ListItemIcon>
+          <ListItemText>대시보드</ListItemText>
+        </ListItem>
+        {categories.map(({id, children}) => (
+          <Box key={id} sx={{bgcolor: '#101F33'}}>
+            <ListItem sx={{py: 2, px: 3}}>
+              <ListItemText sx={{color: '#fff'}}>{id}</ListItemText>
+            </ListItem>
+            {children.map(({id: childId, icon, active}) => (
+              <ListItem disablePadding key={childId}>
+                <ListItemButton selected={active} sx={item}>
+                  <ListItemIcon>{icon}</ListItemIcon>
+                  <ListItemText>{childId}</ListItemText>
+                </ListItemButton>
+              </ListItem>
+            ))}
+
+            <Divider sx={{mt: 2}}/>
+          </Box>
+        ))}
+      </List>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/presentational/dashboard/Paperbase.jsx
+++ b/frontend/src/components/presentational/dashboard/Paperbase.jsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import {createTheme, ThemeProvider} from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Navigator from './Navigator';
+import Content from './Content';
+import Header from './Header';
+
+let theme = createTheme({
+  palette: {
+    primary: {
+      light: '#63ccff',
+      main: '#009be5',
+      dark: '#006db3',
+    },
+  },
+  typography: {
+    h5: {
+      fontWeight: 500,
+      fontSize: 26,
+      letterSpacing: 0.5,
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiTab: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+  },
+  mixins: {
+    toolbar: {
+      minHeight: 48,
+    },
+  },
+});
+
+theme = {
+  ...theme,
+  components: {
+    MuiDrawer: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: '#081627',
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+        contained: {
+          boxShadow: 'none',
+          '&:active': {
+            boxShadow: 'none',
+          },
+        },
+      },
+    },
+    MuiTabs: {
+      styleOverrides: {
+        root: {
+          marginLeft: theme.spacing(1),
+        },
+        indicator: {
+          height: 3,
+          borderTopLeftRadius: 3,
+          borderTopRightRadius: 3,
+          backgroundColor: theme.palette.common.white,
+        },
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          margin: '0 16px',
+          minWidth: 0,
+          padding: 0,
+          [theme.breakpoints.up('md')]: {
+            padding: 0,
+            minWidth: 0,
+          },
+        },
+      },
+    },
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          padding: theme.spacing(1),
+        },
+      },
+    },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          borderRadius: 4,
+        },
+      },
+    },
+    MuiDivider: {
+      styleOverrides: {
+        root: {
+          backgroundColor: 'rgb(255,255,255,0.15)',
+        },
+      },
+    },
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            color: '#4fc3f7',
+          },
+        },
+      },
+    },
+    MuiListItemText: {
+      styleOverrides: {
+        primary: {
+          fontSize: 14,
+          fontWeight: theme.typography.fontWeightMedium,
+        },
+      },
+    },
+    MuiListItemIcon: {
+      styleOverrides: {
+        root: {
+          color: 'inherit',
+          minWidth: 'auto',
+          marginRight: theme.spacing(2),
+          '& svg': {
+            fontSize: 20,
+          },
+        },
+      },
+    },
+    MuiAvatar: {
+      styleOverrides: {
+        root: {
+          width: 32,
+          height: 32,
+        },
+      },
+    },
+  },
+};
+
+const drawerWidth = 256;
+
+export default function Paperbase(props) {
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={{display: 'flex', minHeight: '100vh'}}>
+        <CssBaseline/>
+        <Box
+          component="nav"
+          sx={{width: {sm: drawerWidth}, flexShrink: {sm: 0}}}
+        >
+          <Navigator
+            PaperProps={{style: {width: drawerWidth}}}
+            sx={{display: {sm: 'block', xs: 'none'}}}
+          />
+        </Box>
+        <Box sx={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+          <Header page={props.page}/>
+          <Box component="main" sx={{flex: 1, py: 6, px: 4, bgcolor: '#eaeff1'}}>
+            <Content page={props.page}/>
+          </Box>
+        </Box>
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/frontend/src/pages/DashBoardPage.jsx
+++ b/frontend/src/pages/DashBoardPage.jsx
@@ -1,0 +1,18 @@
+import React, {useEffect} from 'react';
+
+import DashBoardContainer from '../components/containers/DashBoardContainer'
+
+const TITLE = "AutoML - 대시보드";
+
+export default function DashBoardPage() {
+
+  useEffect(() => {
+    document.title = TITLE
+  }, []);
+
+  return (
+    <>
+      <DashBoardContainer/>
+    </>
+  );
+}


### PR DESCRIPTION
- 왼쪽 네비게이션은 고정된 페이지
- 추후 헤더와 컨텐츠를 접속한 URL에 따라 다르게 나타내야 함(현재는 하드코딩된 상태)
- 헤더의 이름과 아이콘은 현재 주석처리된 상태

References:
- https://github.com/pangnem/AutoMLMainWeb/tree/book/frontend/src/paperbase

---
Close #62