### PR TITLE
feat: user테이블의 id 컬럼명을 user_id로 변경

### DIFF
--- a/src/main/java/kr/co/automl/domain/user/User.java
+++ b/src/main/java/kr/co/automl/domain/user/User.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -22,6 +23,7 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
     private String name;
     private String imageUrl;

--- a/src/main/resources/db/migration/V1.1__.change_user_id_column_name.sql
+++ b/src/main/resources/db/migration/V1.1__.change_user_id_column_name.sql
@@ -1,0 +1,3 @@
+-- 20220619: user 테이블의 id 컬럼명을 user_id로 변경
+
+ALTER TABLE user CHANGE ID user_id BIGINT NOT NULL AUTO_INCREMENT;

--- a/src/main/resources/db/migration/V1.1__.change_user_id_column_name.sql
+++ b/src/main/resources/db/migration/V1.1__.change_user_id_column_name.sql
@@ -1,3 +1,3 @@
 -- 20220619: user 테이블의 id 컬럼명을 user_id로 변경
 
-ALTER TABLE user CHANGE ID user_id BIGINT NOT NULL AUTO_INCREMENT;
+ALTER TABLE USER RENAME COLUMN id TO user_id;


### PR DESCRIPTION
객체끼리는 user.id 형식으로 구분이 되지만 DB에서는 FK등을 걸거나 하면
구분하기 힘드므로 넣어주는 것이 좋다.

See Also:
- 실전! 스프링 부트와 JPA 활용1 - 웹 애플리케이션 개발

---
Close #81