### PR TITLE
feat: hibernate 로그 DEBUG 모드로 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,8 @@ spring:
             scope: profile, email
             client-id: ${GOOGLE_OAUTH2_CLIENT_ID}
             client-secret: ${GOOGLE_OAUTH2_CLIENT_SECRET}
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace


### PR DESCRIPTION
운영환경에서는 System.out 보다는 로깅을 사용하는 것이 좋다.

---
Close #91