### PR TITLE
build: JDBC Session 추가 #67

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'org.flywaydb:flyway-core'
 
+    implementation 'org.springframework.session:spring-session-jdbc'
+
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,9 @@ spring:
             client-id: ${GOOGLE_OAUTH2_CLIENT_ID}
             client-secret: ${GOOGLE_OAUTH2_CLIENT_SECRET}
 
+  session:
+    store-type: jdbc
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
세션 저장소는 기본적으로 톰캣 세션을 사용하게 설정되어 있는데, 톰캣이 재시작되면 세션이 풀리는 문제 발생
- 단 현재는 H2만 사용하고 있어서, 나중에 RDS로 변경까지 해야 세션이 풀리지 않는다.

로그인 요청시마다 DB I/O가 발생하여 성능상 이슈가 있을 수 있어 추후 메모리 DB로 변경하는 것을 고려해야 함

See Also:
- (p200) 스프링 부트와 AWS로 혼자 구현하는 웹서비스

---
Close #67