### PR TITLE
perf: WebMvcTest로 변경하여 테스트 속도 향상

### DIFF
--- a/src/test/java/kr/co/automl/HelloControllerTest.java
+++ b/src/test/java/kr/co/automl/HelloControllerTest.java
@@ -1,9 +1,13 @@
 package kr.co.automl;
 
+import kr.co.automl.global.config.security.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -11,7 +15,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(
+        controllers = HelloController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfig.class
+                )
+        }
+)
 @AutoConfigureMockMvc
 class HelloControllerTest {
 
@@ -19,6 +31,7 @@ class HelloControllerTest {
     private MockMvc mockMvc;
 
     @Test
+    @WithMockUser
     void hello() throws Exception {
         ResultActions action = mockMvc.perform(
                 get("/hello")


### PR DESCRIPTION
컴포넌트 스캔에서 Spring Security 제외하도록 설정

See Also:
- (p220) 스프링부트와 AWS로 혼자 구현하는 웹서비스
