### PR TITLE
유저 목록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id "com.github.node-gradle.node" version "3.3.0"
+    id 'org.asciidoctor.convert' version '2.4.0'
 }
 
 group = 'kr.or.automl'
@@ -35,6 +36,13 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
+
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+
+asciidoctor {
+    dependsOn test
 }
 
 tasks.named('test') {

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ### API
 
-- [user](api/user.adoc)
+- [유저 목록 조회](api/get-user.adoc)
 
 ### CI
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,9 @@
 # 문서 목록
 
+### API
+
+- [user](api/user.adoc)
+
 ### CI
+
 - [Gradle 빌드 속도 개선](ci/Gradle_빌드_속도_개선.md)

--- a/docs/api/get-user.adoc
+++ b/docs/api/get-user.adoc
@@ -1,0 +1,13 @@
+== `GET /user` - 유저 목록 조회
+
+=== 어드민이 아닌 유저의 요청
+
+include::{snippets}/get-user-with-not-admin/http-request.adoc[]
+
+include::{snippets}/get-user-with-not-admin/http-response.adoc[]
+
+=== 어드민 유저의 요청
+
+include::{snippets}/get-user/http-request.adoc[]
+
+include::{snippets}/get-user/http-response.adoc[]

--- a/docs/api/user.adoc
+++ b/docs/api/user.adoc
@@ -1,0 +1,5 @@
+== `GET /user` - 유저 목록 조회
+
+include::{snippets}/user/http-request.adoc[]
+
+include::{snippets}/user/http-response.adoc[]

--- a/docs/api/user.adoc
+++ b/docs/api/user.adoc
@@ -1,5 +1,0 @@
-== `GET /user` - 유저 목록 조회
-
-include::{snippets}/user/http-request.adoc[]
-
-include::{snippets}/user/http-response.adoc[]

--- a/src/main/java/kr/co/automl/domain/user/User.java
+++ b/src/main/java/kr/co/automl/domain/user/User.java
@@ -1,6 +1,7 @@
 package kr.co.automl.domain.user;
 
 import kr.co.automl.domain.user.dto.SessionUser;
+import kr.co.automl.domain.user.dto.UserResponse;
 import kr.co.automl.domain.user.exceptions.CannotChangeAdminRoleException;
 import kr.co.automl.global.config.security.dto.OAuthAttributes;
 import lombok.AccessLevel;
@@ -21,7 +22,7 @@ import java.util.Objects;
 @Entity
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter(value = AccessLevel.PACKAGE)
+@Getter
 public class User {
 
     @Id
@@ -59,10 +60,6 @@ public class User {
                 .email(email)
                 .role(Role.DEFAULT)
                 .build();
-    }
-
-    public long id() {
-        return this.id;
     }
 
     public SessionUser toSessionUser() {
@@ -106,5 +103,9 @@ public class User {
         }
 
         this.role = role;
+    }
+
+    public UserResponse toResponse() {
+        return new UserResponse(id, name, email, role);
     }
 }

--- a/src/main/java/kr/co/automl/domain/user/UserRepository.java
+++ b/src/main/java/kr/co/automl/domain/user/UserRepository.java
@@ -1,6 +1,8 @@
 package kr.co.automl.domain.user;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 public interface UserRepository {
@@ -12,5 +14,5 @@ public interface UserRepository {
 
     Optional<User> findById(long userId);
 
-    List<User> findAll();
+    Page<User> findAll(Pageable pageable);
 }

--- a/src/main/java/kr/co/automl/domain/user/UserRepository.java
+++ b/src/main/java/kr/co/automl/domain/user/UserRepository.java
@@ -1,5 +1,6 @@
 package kr.co.automl.domain.user;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -10,4 +11,6 @@ public interface UserRepository {
     void deleteAll();
 
     Optional<User> findById(long userId);
+
+    List<User> findAll();
 }

--- a/src/main/java/kr/co/automl/domain/user/api/UserApi.java
+++ b/src/main/java/kr/co/automl/domain/user/api/UserApi.java
@@ -1,0 +1,21 @@
+package kr.co.automl.domain.user.api;
+
+import kr.co.automl.domain.user.dto.UserResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("user")
+@PreAuthorize("hasRole('ADMIN')")
+public class UserApi {
+
+    @GetMapping
+    public List<UserResponse> users() {
+        // TODO: 2022/06/27 구현 필요!
+        return null;
+    }
+}

--- a/src/main/java/kr/co/automl/domain/user/api/UserApi.java
+++ b/src/main/java/kr/co/automl/domain/user/api/UserApi.java
@@ -3,6 +3,7 @@ package kr.co.automl.domain.user.api;
 import kr.co.automl.domain.user.dto.UserResponse;
 import kr.co.automl.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +19,9 @@ public class UserApi {
     private final UserService userService;
 
     @GetMapping
-    public List<UserResponse> users() {
-        return userService.getUsers();
+    public List<UserResponse> users(
+            Pageable pageable
+    ) {
+        return userService.getUsers(pageable);
     }
 }

--- a/src/main/java/kr/co/automl/domain/user/api/UserApi.java
+++ b/src/main/java/kr/co/automl/domain/user/api/UserApi.java
@@ -1,6 +1,8 @@
 package kr.co.automl.domain.user.api;
 
 import kr.co.automl.domain.user.dto.UserResponse;
+import kr.co.automl.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,11 +13,12 @@ import java.util.List;
 @RestController
 @RequestMapping("user")
 @PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
 public class UserApi {
+    private final UserService userService;
 
     @GetMapping
     public List<UserResponse> users() {
-        // TODO: 2022/06/27 구현 필요!
-        return null;
+        return userService.getUsers();
     }
 }

--- a/src/main/java/kr/co/automl/domain/user/dto/UserResponse.java
+++ b/src/main/java/kr/co/automl/domain/user/dto/UserResponse.java
@@ -1,0 +1,18 @@
+package kr.co.automl.domain.user.dto;
+
+import kr.co.automl.domain.user.Role;
+
+public record UserResponse(
+        long id,
+        String name,
+        String email,
+        Role role
+) {
+
+    public UserResponse(long id, String name, String email, Role role) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/kr/co/automl/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/automl/domain/user/service/UserService.java
@@ -1,0 +1,27 @@
+package kr.co.automl.domain.user.service;
+
+import kr.co.automl.domain.user.User;
+import kr.co.automl.domain.user.UserRepository;
+import kr.co.automl.domain.user.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    /**
+     * 유저 응답 객체 목록을 리턴합니다.
+     */
+    public List<UserResponse> getUsers() {
+        List<User> users = userRepository.findAll();
+
+        return users.stream()
+                .map(User::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/kr/co/automl/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/automl/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import kr.co.automl.domain.user.User;
 import kr.co.automl.domain.user.UserRepository;
 import kr.co.automl.domain.user.dto.UserResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,8 +18,9 @@ public class UserService {
     /**
      * 유저 응답 객체 목록을 리턴합니다.
      */
-    public List<UserResponse> getUsers() {
-        List<User> users = userRepository.findAll();
+    public List<UserResponse> getUsers(Pageable pageable) {
+        List<User> users = userRepository.findAll(pageable)
+                .getContent();
 
         return users.stream()
                 .map(User::toResponse)

--- a/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
+++ b/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
@@ -52,7 +52,11 @@ public class InMemoryUserRepository implements UserRepository {
         int pageSize = pageable.getPageSize();
 
         int start = pageNumber * pageSize;
-        int last = Math.min((1 + pageNumber) * pageSize, users.size());
+        int last = (1 + pageNumber) * pageSize;
+
+        if (last > users.size()) {
+            last = users.size();
+        }
 
         return new PageImpl<>(users.subList(start, last), pageable, users.size());
     }

--- a/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
+++ b/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
@@ -44,8 +44,7 @@ public class InMemoryUserRepository implements UserRepository {
 
     @Override
     public Page<User> findAll(Pageable pageable) {
-        Collection<User> values = map.values();
-        List<User> users = values.stream()
+        List<User> users = users().stream()
                 .toList();
 
         int pageNumber = pageable.getPageNumber();

--- a/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
+++ b/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
@@ -24,7 +24,7 @@ public class InMemoryUserRepository implements UserRepository {
             remove(user);
         }
 
-        long id = user.id();
+        long id = user.getId();
         map.put(id, user);
 
         return user;

--- a/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
+++ b/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
@@ -2,6 +2,9 @@ package kr.co.automl.infra;
 
 import kr.co.automl.domain.user.User;
 import kr.co.automl.domain.user.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Collection;
 import java.util.List;
@@ -21,10 +24,6 @@ public class InMemoryUserRepository implements UserRepository {
 
     @Override
     public User save(User user) {
-        if (existEmail(user)) {
-            remove(user);
-        }
-
         long id = user.getId();
         map.put(id, user);
 
@@ -44,20 +43,18 @@ public class InMemoryUserRepository implements UserRepository {
     }
 
     @Override
-    public List<User> findAll() {
+    public Page<User> findAll(Pageable pageable) {
         Collection<User> values = map.values();
-
-        return values.stream()
+        List<User> users = values.stream()
                 .toList();
-    }
 
-    private void remove(User user) {
-        users().remove(user);
-    }
+        int pageNumber = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
 
-    private boolean existEmail(User user) {
-        return users().stream()
-                .anyMatch(user::matchEmail);
+        int start = pageNumber * pageSize;
+        int last = Math.min((1 + pageNumber) * pageSize, users.size());
+
+        return new PageImpl<>(users.subList(start, last), pageable, users.size());
     }
 
     private Collection<User> users() {

--- a/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
+++ b/src/main/java/kr/co/automl/infra/InMemoryUserRepository.java
@@ -4,6 +4,7 @@ import kr.co.automl.domain.user.User;
 import kr.co.automl.domain.user.UserRepository;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +41,14 @@ public class InMemoryUserRepository implements UserRepository {
         User user = map.get(userId);
 
         return Optional.ofNullable(user);
+    }
+
+    @Override
+    public List<User> findAll() {
+        Collection<User> values = map.values();
+
+        return values.stream()
+                .toList();
     }
 
     private void remove(User user) {

--- a/src/main/java/kr/co/automl/infra/JpaUserRepository.java
+++ b/src/main/java/kr/co/automl/infra/JpaUserRepository.java
@@ -3,8 +3,8 @@ package kr.co.automl.infra;
 import kr.co.automl.domain.user.User;
 import kr.co.automl.domain.user.UserRepository;
 import org.springframework.context.annotation.Primary;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 @Primary
-public interface JpaUserRepository extends UserRepository, CrudRepository<User, Long> {
+public interface JpaUserRepository extends UserRepository, JpaRepository<User, Long> {
 }

--- a/src/test/java/kr/co/automl/domain/user/UserTest.java
+++ b/src/test/java/kr/co/automl/domain/user/UserTest.java
@@ -1,6 +1,7 @@
 package kr.co.automl.domain.user;
 
 import kr.co.automl.domain.user.dto.SessionUser;
+import kr.co.automl.domain.user.dto.UserResponse;
 import kr.co.automl.domain.user.exceptions.CannotChangeAdminRoleException;
 import kr.co.automl.global.config.security.dto.OAuthAttributes;
 import org.junit.jupiter.api.Nested;
@@ -208,5 +209,18 @@ public class UserTest {
             }
         }
 
+    }
+
+    @Nested
+    class toResponse {
+
+        @Test
+        void 변환된_응답_리턴() {
+            User user = create();
+
+            UserResponse userResponse = user.toResponse();
+
+            assertThat(userResponse).isEqualTo(new UserResponse(0L, "name", "email", Role.USER));
+        }
     }
 }

--- a/src/test/java/kr/co/automl/domain/user/api/UserApiTest.java
+++ b/src/test/java/kr/co/automl/domain/user/api/UserApiTest.java
@@ -51,7 +51,8 @@ class UserApiTest {
                 ResultActions action = mockMvc.perform(request);
 
                 action
-                        .andExpect(status().isForbidden());
+                        .andExpect(status().isForbidden())
+                        .andDo(document("get-user-with-not-admin"));
             }
         }
 
@@ -75,7 +76,7 @@ class UserApiTest {
                 action
                         .andExpect(status().isOk())
                         .andExpect(content().string(convert(List.of(savedUser.toResponse()))))
-                        .andDo(document("user"));
+                        .andDo(document("get-user"));
             }
         }
     }

--- a/src/test/java/kr/co/automl/domain/user/api/UserApiTest.java
+++ b/src/test/java/kr/co/automl/domain/user/api/UserApiTest.java
@@ -1,0 +1,78 @@
+package kr.co.automl.domain.user.api;
+
+import kr.co.automl.domain.user.User;
+import kr.co.automl.domain.user.UserRepository;
+import kr.co.automl.domain.user.UserTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static kr.co.automl.domain.user.utils.ObjectToStringConverter.convert;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Nested
+    @DisplayName("GET /user 요청은")
+    class get_user_요청은 {
+        MockHttpServletRequestBuilder request = get("/user");
+
+        @Nested
+        class 어드민이_아닌_유저의_요청일경우 {
+
+            @Test
+            @WithMockUser(roles = {"USER, MANAGER"})
+            void status_403을_응답한다() throws Exception {
+                ResultActions action = mockMvc.perform(request);
+
+                action
+                        .andExpect(status().isForbidden());
+            }
+        }
+
+        @Nested
+        class 어드민_유저의_요청일경우 {
+            private User savedUser;
+
+            @BeforeEach
+            void setUp() {
+                User user = UserTest.create();
+                userRepository.save(user);
+
+                this.savedUser = user;
+            }
+
+            @Test
+            @WithMockUser(roles = {"ADMIN"})
+            void status_200을_응답하고_유저목록을_리턴한다() throws Exception {
+                ResultActions action = mockMvc.perform(request);
+
+                action
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(convert(List.of(savedUser.toResponse()))));
+            }
+        }
+    }
+}

--- a/src/test/java/kr/co/automl/domain/user/api/UserApiTest.java
+++ b/src/test/java/kr/co/automl/domain/user/api/UserApiTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -19,12 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static kr.co.automl.domain.user.utils.ObjectToStringConverter.convert;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 @Transactional
 class UserApiTest {
 
@@ -71,7 +74,8 @@ class UserApiTest {
 
                 action
                         .andExpect(status().isOk())
-                        .andExpect(content().string(convert(List.of(savedUser.toResponse()))));
+                        .andExpect(content().string(convert(List.of(savedUser.toResponse()))))
+                        .andDo(document("user"));
             }
         }
     }

--- a/src/test/java/kr/co/automl/domain/user/api/UserRoleApiTest.java
+++ b/src/test/java/kr/co/automl/domain/user/api/UserRoleApiTest.java
@@ -92,7 +92,7 @@ class UserRoleApiTest {
             @WithMockUser(roles = {"ADMIN"})
             void status_200을_응답한다() throws Exception {
                 ResultActions action = mockMvc.perform(
-                        put(String.format("/user/%s/role", savedUser.id()))
+                        put(String.format("/user/%s/role", savedUser.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(convert(CHANGE_USER_ROLE_REQUEST1))
                 );

--- a/src/test/java/kr/co/automl/domain/user/service/UserRoleChangerTest.java
+++ b/src/test/java/kr/co/automl/domain/user/service/UserRoleChangerTest.java
@@ -36,7 +36,7 @@ class UserRoleChangerTest {
                 User user = UserTest.createWithId(1L);
                 userRepository.save(user);
 
-                this.existUserId = user.id();
+                this.existUserId = user.getId();
             }
 
             @Test

--- a/src/test/java/kr/co/automl/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/automl/domain/user/service/UserServiceTest.java
@@ -1,6 +1,5 @@
 package kr.co.automl.domain.user.service;
 
-import kr.co.automl.domain.user.User;
 import kr.co.automl.domain.user.UserRepository;
 import kr.co.automl.domain.user.UserTest;
 import kr.co.automl.domain.user.dto.UserResponse;
@@ -8,8 +7,10 @@ import kr.co.automl.infra.InMemoryUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,23 +27,21 @@ class UserServiceTest {
 
     @Nested
     class getUsers {
-        private User savedUser;
 
         @BeforeEach
-        void setUp() {
-            User user = UserTest.create();
-            userRepository.save(user);
-
-            this.savedUser = user;
+        void setUp_유저_11명_저장() {
+            IntStream.range(0, 11)
+                    .mapToObj(UserTest::createWithId)
+                    .forEach(user -> userRepository.save(user));
         }
 
         @Test
-        void 목록_리턴() {
-            List<UserResponse> users = userService.getUsers();
+        void 페이지네이션_테스트_11개를넣어도_10개가_나온다() {
+            List<UserResponse> users = userService.getUsers(PageRequest.of(0, 10));
+            assertThat(users).hasSize(10);
 
-            assertThat(users).isEqualTo(List.of(
-                    savedUser.toResponse())
-            );
+            users = userService.getUsers(PageRequest.of(1, 10));
+            assertThat(users).hasSize(1);
         }
     }
 }

--- a/src/test/java/kr/co/automl/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/automl/domain/user/service/UserServiceTest.java
@@ -1,0 +1,48 @@
+package kr.co.automl.domain.user.service;
+
+import kr.co.automl.domain.user.User;
+import kr.co.automl.domain.user.UserRepository;
+import kr.co.automl.domain.user.UserTest;
+import kr.co.automl.domain.user.dto.UserResponse;
+import kr.co.automl.infra.InMemoryUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserServiceTest {
+
+    private UserService userService;
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        this.userRepository = new InMemoryUserRepository();
+        this.userService = new UserService(userRepository);
+    }
+
+    @Nested
+    class getUsers {
+        private User savedUser;
+
+        @BeforeEach
+        void setUp() {
+            User user = UserTest.create();
+            userRepository.save(user);
+
+            this.savedUser = user;
+        }
+
+        @Test
+        void 목록_리턴() {
+            List<UserResponse> users = userService.getUsers();
+
+            assertThat(users).isEqualTo(List.of(
+                    savedUser.toResponse())
+            );
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,3 +7,6 @@ spring:
             scope: profile, email
             client-id: test
             client-secret: test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
- test: 유저 목록 API 통합 테스트
- feat: 유저 목록을 불러오는 서비스 구현
- feat: 유저 목록 페이지네이션 구현 #139
- refactor: InMemoryUserRepository.findAll 마지막 인덱스 변수 설정 가독성 개선
- refactor: 존재하는 users() 메서드로 교체

### 의존성 변경사항
- Spring REST Docs 관련 의존성 추가됨