### PR TITLE
유저 권한 설정 화면 구현

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ### API
 
 - [유저 목록 조회](api/get-user.adoc)
+- [유저 권한 변경 요청](api/put-user-role.adoc)
 
 ### CI
 

--- a/docs/api/get-user.adoc
+++ b/docs/api/get-user.adoc
@@ -1,13 +1,11 @@
 == `GET /user` - 유저 목록 조회
 
-=== 어드민이 아닌 유저의 요청
+=== 어드민이 아닌 유저의 요청과 응답
 
 include::{snippets}/get-user-with-not-admin/http-request.adoc[]
-
 include::{snippets}/get-user-with-not-admin/http-response.adoc[]
 
-=== 어드민 유저의 요청
+=== 어드민 유저의 요청과 응답
 
 include::{snippets}/get-user/http-request.adoc[]
-
 include::{snippets}/get-user/http-response.adoc[]

--- a/docs/api/put-user-role.adoc
+++ b/docs/api/put-user-role.adoc
@@ -1,0 +1,17 @@
+== `PUT /user/{id}/role` 유저 권한 변경 요청
+
+=== 어드민이 아닌 유저의 요청과 응답
+
+include::{snippets}/put-user-role-with-not-admin/http-request.adoc[]
+include::{snippets}/put-user-role-with-not-admin/http-response.adoc[]
+
+=== 존재하지 않는 유저에 대한 요청과 응답
+
+include::{snippets}/put-user-role-with-not-exist-id/http-request.adoc[]
+include::{snippets}/put-user-role-with-not-exist-id/http-response.adoc[]
+
+=== 존재하는 유저에 대한 요청과 응답
+
+include::{snippets}/put-user-role-with-exist-id/http-request.adoc[]
+include::{snippets}/put-user-role-with-exist-id/http-response.adoc[]
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.3",
+        "@mui/x-data-grid": "^5.12.3",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2378,6 +2379,31 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-data-grid": {
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.12.3.tgz",
+      "integrity": "sha512-57A2MkRR/uUNC/dECFV0YDJvi1Q+gQgmgw1OHmZ1uSnKh29PcHpswkdapO0LueLpxAy8tfH+fTtnnPDmYgJeUg==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.4.1",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@nodelib/fs.stat": {
@@ -17886,6 +17912,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
+    },
     "node_modules/resolve": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -23152,6 +23183,18 @@
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
         "react-is": "^17.0.2"
+      }
+    },
+    "@mui/x-data-grid": {
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.12.3.tgz",
+      "integrity": "sha512-57A2MkRR/uUNC/dECFV0YDJvi1Q+gQgmgw1OHmZ1uSnKh29PcHpswkdapO0LueLpxAy8tfH+fTtnnPDmYgJeUg==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.4.1",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.6"
       }
     },
     "@nodelib/fs.stat": {
@@ -35537,6 +35580,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.3",
+    "@mui/x-data-grid": "^5.12.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -4,3 +4,17 @@ export async function getUserInfo() {
   return axios.get("/user/info")
     .then(response => response.data)
 }
+
+export async function getUsers() {
+  return axios.get("/user")
+    .then(response => response.data);
+}
+
+export async function putUsersRole(ids, role) {
+  return axios.all(
+    ids.map(id => axios.put(`/user/${id}/role`, {
+        role: role
+      })
+    )
+  );
+}

--- a/frontend/src/components/containers/user/UserRoleManagementContainer.jsx
+++ b/frontend/src/components/containers/user/UserRoleManagementContainer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Header from "../../presentational/Header";
 import MainBox from "../MainBox";
-import ToDoContent from "../../presentational/ToDoContent";
+import UserRoleManagementContent from "../../presentational/user/UserGrid";
 
 export default function UserRoleManagementContainer(props) {
   const {mainTitle, tabNames} = props;
@@ -12,7 +12,7 @@ export default function UserRoleManagementContainer(props) {
       tabNames={tabNames}
     />
     <MainBox
-      content={<ToDoContent/>}
+      content={<UserRoleManagementContent/>}
     />
   </>;
 }

--- a/frontend/src/components/containers/user/UserRoleManagementContainer.jsx
+++ b/frontend/src/components/containers/user/UserRoleManagementContainer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Header from "../../presentational/Header";
 import MainBox from "../MainBox";
-import UserRoleManagementContent from "../../presentational/user/UserGrid";
+import UserRoleManagementContent from "../../presentational/user/UserRoleManagementContent";
 
 export default function UserRoleManagementContainer(props) {
   const {mainTitle, tabNames} = props;

--- a/frontend/src/components/presentational/user/UserGrid.jsx
+++ b/frontend/src/components/presentational/user/UserGrid.jsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+import {DataGrid} from '@mui/x-data-grid';
+import Box from "@mui/material/Box";
+import {getUsers, putUsersRole} from "../../../api/user";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select
+} from "@mui/material";
+
+const columns = [
+  {
+    field: 'id',
+    headerName: '아이디',
+    width: 90
+  },
+  {
+    field: 'name',
+    headerName: '이름',
+    width: 150,
+  },
+  {
+    field: 'email',
+    headerName: '이메일',
+    width: 150,
+  },
+  {
+    field: 'role',
+    headerName: '권한',
+    width: 110,
+  },
+];
+
+export default function UserGrid() {
+  const [users, setUsers] = useState([]);
+  const [ids, setIds] = useState([]);
+  const [role, setRole] = useState('');
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    getUsers()
+      .then(users => setUsers(users));
+  }, []);
+
+  const openDialog = () => {
+    setDialogOpen(true);
+  }
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+  }
+
+  const changeUsersRole = () => {
+    putUsersRole(ids, role)
+      .then(value => {
+        alert("변경 완료되었습니다.")
+        window.location.reload();
+      })
+      .catch(err => {
+        alert(`에러가 발생했습니다: ${err.message}`);
+        window.location.reload();
+      });
+  }
+
+  return <>
+    <Box sx={{height: 400, width: '70%'}}>
+      <DataGrid
+        rows={users}
+        columns={columns}
+        pageSize={5}
+        rowsPerPageOptions={[5]}
+        checkboxSelection
+        disableSelectionOnClick
+        onSelectionModelChange={(ids) => {
+          setIds(ids);
+        }}
+      />
+      <Button onClick={() => openDialog()}>
+        수정하기
+      </Button>
+    </Box>
+
+    <Dialog disableEscapeKeyDown open={dialogOpen} onClose={closeDialog}>
+      <DialogTitle>변경할 권한 선택</DialogTitle>
+      <DialogContent>
+        <Box component="form" sx={{display: 'flex', flexWrap: 'wrap'}}>
+          <FormControl sx={{m: 1, minWidth: 200}}>
+            <InputLabel id="demo-dialog-select-label">권한</InputLabel>
+            <Select
+              labelId="demo-dialog-select-label"
+              id="demo-dialog-select"
+              value={role}
+              onChange={event => setRole(event.target.value)}
+              input={<OutlinedInput label="변경할 권한 선택"/>}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              <MenuItem value={"USER"}>USER</MenuItem>
+              <MenuItem value={"MANAGER"}>MANAGER</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={closeDialog}>Cancel</Button>
+        <Button onClick={changeUsersRole}>Ok</Button>
+      </DialogActions>
+    </Dialog>
+
+  </>
+
+}

--- a/frontend/src/components/presentational/user/UserGrid.jsx
+++ b/frontend/src/components/presentational/user/UserGrid.jsx
@@ -39,10 +39,16 @@ const columns = [
   },
 ];
 
+const EMPTY_STRING = "";
+
+const reload = () => {
+  window.location.reload();
+}
+
 export default function UserGrid() {
   const [users, setUsers] = useState([]);
-  const [ids, setIds] = useState([]);
-  const [role, setRole] = useState('');
+  const [userIds, setUserIds] = useState([]);
+  const [role, setRole] = useState(EMPTY_STRING);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -51,6 +57,11 @@ export default function UserGrid() {
   }, []);
 
   const openDialog = () => {
+    if (userIds.length === 0) {
+      alert("유저를 먼저 선택해주세요");
+      return;
+    }
+
     setDialogOpen(true);
   }
 
@@ -59,14 +70,18 @@ export default function UserGrid() {
   }
 
   const changeUsersRole = () => {
-    putUsersRole(ids, role)
-      .then(value => {
+    if (role === EMPTY_STRING) {
+      return;
+    }
+
+    putUsersRole(userIds, role)
+      .then(_ => {
         alert("변경 완료되었습니다.")
-        window.location.reload();
+        reload();
       })
       .catch(err => {
         alert(`에러가 발생했습니다: ${err.message}`);
-        window.location.reload();
+        reload();
       });
   }
 
@@ -80,7 +95,7 @@ export default function UserGrid() {
         checkboxSelection
         disableSelectionOnClick
         onSelectionModelChange={(ids) => {
-          setIds(ids);
+          setUserIds(ids);
         }}
       />
       <Button onClick={() => openDialog()}>
@@ -96,13 +111,12 @@ export default function UserGrid() {
             <InputLabel id="demo-dialog-select-label">권한</InputLabel>
             <Select
               labelId="demo-dialog-select-label"
-              id="demo-dialog-select"
               value={role}
               onChange={event => setRole(event.target.value)}
               input={<OutlinedInput label="변경할 권한 선택"/>}
             >
-              <MenuItem value="">
-                <em>None</em>
+              <MenuItem value={EMPTY_STRING}>
+                <em>권한 선택</em>
               </MenuItem>
               <MenuItem value={"USER"}>USER</MenuItem>
               <MenuItem value={"MANAGER"}>MANAGER</MenuItem>

--- a/frontend/src/components/presentational/user/UserRoleManagementContent.jsx
+++ b/frontend/src/components/presentational/user/UserRoleManagementContent.jsx
@@ -108,9 +108,9 @@ export default function UserRoleManagementContent() {
       <DialogContent>
         <Box component="form" sx={{display: 'flex', flexWrap: 'wrap'}}>
           <FormControl sx={{m: 1, minWidth: 200}}>
-            <InputLabel id="demo-dialog-select-label">권한</InputLabel>
+            <InputLabel id="권한 선택 라벨">권한</InputLabel>
             <Select
-              labelId="demo-dialog-select-label"
+              labelId="권한 선택 라벨"
               value={role}
               onChange={event => setRole(event.target.value)}
               input={<OutlinedInput label="변경할 권한 선택"/>}

--- a/frontend/src/components/presentational/user/UserRoleManagementContent.jsx
+++ b/frontend/src/components/presentational/user/UserRoleManagementContent.jsx
@@ -45,7 +45,7 @@ const reload = () => {
   window.location.reload();
 }
 
-export default function UserGrid() {
+export default function UserRoleManagementContent() {
   const [users, setUsers] = useState([]);
   const [userIds, setUserIds] = useState([]);
   const [role, setRole] = useState(EMPTY_STRING);

--- a/src/main/java/kr/co/automl/domain/user/Role.java
+++ b/src/main/java/kr/co/automl/domain/user/Role.java
@@ -1,5 +1,9 @@
 package kr.co.automl.domain.user;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Objects;
+
 public enum Role {
     USER, MANAGER, ADMIN;
 
@@ -21,4 +25,16 @@ public enum Role {
     public boolean isAdmin() {
         return this == ADMIN;
     }
+
+    @JsonCreator
+    public static Role getNameByValue(String value) {
+        for (Role role : Role.values()) {
+            if (Objects.equals(role.toString(), value)) {
+                return role;
+            }
+        }
+
+        return null;
+    }
+
 }

--- a/src/main/java/kr/co/automl/domain/user/User.java
+++ b/src/main/java/kr/co/automl/domain/user/User.java
@@ -2,6 +2,7 @@ package kr.co.automl.domain.user;
 
 import kr.co.automl.domain.user.dto.SessionUser;
 import kr.co.automl.domain.user.dto.UserResponse;
+import kr.co.automl.domain.user.exceptions.AlreadyAdminRoleException;
 import kr.co.automl.domain.user.exceptions.CannotChangeAdminRoleException;
 import kr.co.automl.global.config.security.dto.OAuthAttributes;
 import lombok.AccessLevel;
@@ -92,14 +93,21 @@ public class User {
     }
 
     /**
-     * 권한을 변경합니다. 어드민 권한으로는 변경할 수 없습니다.
+     * 권한을 변경합니다.
+     *
+     * 변경할 권한이 어드민 권한이거나 이미 어드민인 유저는 변경될 수 없습니다.
      * @param role 변경할 권한
      *
      * @throws CannotChangeAdminRoleException 어드민 권한이 주어진경우
+     * @throws AlreadyAdminRoleException 이미 어드민 권한을 가진 유저일경우
      */
     public void changeRoleTo(Role role) {
         if (role.isAdmin()) {
             throw new CannotChangeAdminRoleException();
+        }
+
+        if (this.role.isAdmin()) {
+            throw new AlreadyAdminRoleException();
         }
 
         this.role = role;

--- a/src/main/java/kr/co/automl/domain/user/exceptions/AlreadyAdminRoleException.java
+++ b/src/main/java/kr/co/automl/domain/user/exceptions/AlreadyAdminRoleException.java
@@ -1,0 +1,8 @@
+package kr.co.automl.domain.user.exceptions;
+
+public class AlreadyAdminRoleException extends RuntimeException {
+
+    public AlreadyAdminRoleException() {
+        super("이미 어드민 권한을 가진 유저입니다.");
+    }
+}

--- a/src/main/java/kr/co/automl/domain/user/service/UserRoleChanger.java
+++ b/src/main/java/kr/co/automl/domain/user/service/UserRoleChanger.java
@@ -29,7 +29,5 @@ public class UserRoleChanger {
                 .orElseThrow(() -> new CannotFindUserException(userId));
 
         user.changeRoleTo(role);
-
-        userRepository.save(user);
     }
 }

--- a/src/main/java/kr/co/automl/global/utils/web/FrontendUrlRequestHandler.java
+++ b/src/main/java/kr/co/automl/global/utils/web/FrontendUrlRequestHandler.java
@@ -5,16 +5,22 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
-@PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
 public class FrontendUrlRequestHandler {
 
     @GetMapping(value = {
             "/dashboard",
             "/metadata/**",
-            "/user/**"
     })
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
     public String returnToIndexHtml() {
         return "/index.html";
     }
 
+    @GetMapping(value = {
+            "/user/**"
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    public String returnToIndexHtmlOnlyAdmin() {
+        return "/index.html";
+    }
 }

--- a/src/main/java/kr/co/automl/global/utils/web/GlobalControllerAdvice.java
+++ b/src/main/java/kr/co/automl/global/utils/web/GlobalControllerAdvice.java
@@ -1,5 +1,6 @@
 package kr.co.automl.global.utils.web;
 
+import kr.co.automl.domain.user.exceptions.AlreadyAdminRoleException;
 import kr.co.automl.domain.user.exceptions.CannotFindUserException;
 import kr.co.automl.global.utils.web.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
@@ -11,7 +12,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class GlobalControllerAdvice {
 
     @ExceptionHandler({
-            CannotFindUserException.class
+            CannotFindUserException.class,
+            AlreadyAdminRoleException.class
     })
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse responseBadRequestAndReturnErrorResponse(

--- a/src/test/java/kr/co/automl/domain/user/UserTest.java
+++ b/src/test/java/kr/co/automl/domain/user/UserTest.java
@@ -2,6 +2,7 @@ package kr.co.automl.domain.user;
 
 import kr.co.automl.domain.user.dto.SessionUser;
 import kr.co.automl.domain.user.dto.UserResponse;
+import kr.co.automl.domain.user.exceptions.AlreadyAdminRoleException;
 import kr.co.automl.domain.user.exceptions.CannotChangeAdminRoleException;
 import kr.co.automl.global.config.security.dto.OAuthAttributes;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +32,7 @@ public class UserTest {
     public static User createWithId(long id) {
         return User.builder()
                 .id(id)
+                .role(Role.USER)
                 .build();
     }
 
@@ -209,6 +211,25 @@ public class UserTest {
             }
         }
 
+        @Nested
+        class 이미_어드민_유저일경우 {
+
+            @ParameterizedTest
+            @EnumSource(
+                    value = Role.class,
+                    mode = EnumSource.Mode.EXCLUDE,
+                    names = {"ADMIN"}
+            )
+            void AlreadyAdminRoleException을_던진다(Role role) {
+                User adminUser = User.builder()
+                        .role(Role.ADMIN)
+                        .build();
+
+                assertThatThrownBy(() -> adminUser.changeRoleTo(role))
+                        .isInstanceOf(AlreadyAdminRoleException.class)
+                        .hasMessage("이미 어드민 권한을 가진 유저입니다.");
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/kr/co/automl/domain/user/api/UserRoleApiTest.java
+++ b/src/test/java/kr/co/automl/domain/user/api/UserRoleApiTest.java
@@ -8,22 +8,24 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static kr.co.automl.domain.user.dto.ChangeUserRoleRequestTest.CHANGE_USER_ROLE_REQUEST1;
 import static kr.co.automl.domain.user.utils.ObjectToStringConverter.convert;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 @Transactional
 class UserRoleApiTest {
 
@@ -36,8 +38,6 @@ class UserRoleApiTest {
     @Nested
     @DisplayName("PUT /user/{userId}/role 요청은")
     class put_user_role_요청은 {
-        MockHttpServletRequestBuilder request = put("/user/role")
-                .contentType(MediaType.APPLICATION_JSON);
 
         @Nested
         @WithMockUser(roles = {"USER", "MANAGER"})
@@ -52,7 +52,8 @@ class UserRoleApiTest {
                 );
 
                 action
-                        .andExpect(status().isForbidden());
+                        .andExpect(status().isForbidden())
+                        .andDo(document("put-user-role-with-not-admin"));
             }
         }
 
@@ -74,7 +75,8 @@ class UserRoleApiTest {
                 );
 
                 action
-                        .andExpect(status().isBadRequest());
+                        .andExpect(status().isBadRequest())
+                        .andDo(document("put-user-role-with-not-exist-id"));
             }
         }
 
@@ -98,7 +100,8 @@ class UserRoleApiTest {
                 );
 
                 action
-                        .andExpect(status().isOk());
+                        .andExpect(status().isOk())
+                        .andDo(document("put-user-role-with-exist-id"));
             }
         }
     }


### PR DESCRIPTION
- build: @mui/x-data-grid 추가
- docs: 권한 변경 요청 api 문서 추가
- fix: Role Enum에 JsonCreator 추가
- feat: 유저 권한 관리 화면 개발
- feat: 이미 어드민인 유저는 권한을 변경하지 못하도록 구현
- perf: 유저 권한 관리 화면 개선
- refactor(rename): UserGrid.jsx 에서 UserRoleManagementContent로 변경
- fix: 라벨명 수정
- feat: 어드민만 유저 관리 페이지 접근 가능하도록 설정

---
화면 개발하면서 서버 수정이 필요한 부분은 같이 수정하였음.

Close #138, #141
