### PR TITLE
카탈로그 및 테마 상수 추가

### DIFF
--- a/src/main/java/kr/co/automl/domain/metadata/Catalog.java
+++ b/src/main/java/kr/co/automl/domain/metadata/Catalog.java
@@ -1,0 +1,43 @@
+package kr.co.automl.domain.metadata;
+
+import kr.co.automl.domain.metadata.exceptions.CannotFindMatchCatalogException;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public enum Catalog {
+
+    ATMOSPHERIC_ENVIRONMENT("대기 환경"),
+    FARM("농장"),
+    FACTORY("공장"),
+    VITAL("생체"),
+    LIFE_AND_VIDEO("생활/영상"),
+    ENERGY("에너지"),
+    ENVIRONMENT("환경"),
+    CITY("도시"),
+    OPEN_DATA("오픈데이터");
+
+    private final String name;
+
+    Catalog(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 카탈로그 이름으로 일치하는 카탈로그를 찾아 리턴합니다.
+     * @param name 찾을 카탈로그 이름
+     * @return 찾은 카탈로그
+     *
+     * @throws CannotFindMatchCatalogException 이름으로 카탈로그를 찾지 못한 경우
+     */
+    public static Catalog ofName(String name) {
+        return Arrays.stream(values())
+                .filter(catalog -> catalog.matchName(name))
+                .findFirst()
+                .orElseThrow(() -> new CannotFindMatchCatalogException(name));
+    }
+
+    private boolean matchName(String name) {
+        return Objects.equals(this.name, name);
+    }
+}

--- a/src/main/java/kr/co/automl/domain/metadata/Catalog.java
+++ b/src/main/java/kr/co/automl/domain/metadata/Catalog.java
@@ -1,26 +1,54 @@
 package kr.co.automl.domain.metadata;
 
 import kr.co.automl.domain.metadata.exceptions.CannotFindMatchCatalogException;
+import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeException;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 
 public enum Catalog {
 
-    ATMOSPHERIC_ENVIRONMENT("대기 환경"),
-    FARM("농장"),
-    FACTORY("공장"),
-    VITAL("생체"),
-    LIFE_AND_VIDEO("생활/영상"),
-    ENERGY("에너지"),
-    ENVIRONMENT("환경"),
-    CITY("도시"),
-    OPEN_DATA("오픈데이터");
+    ATMOSPHERIC_ENVIRONMENT("대기 환경", Set.of(
+            Theme.AIR_QUALITY
+    )),
+    FARM("농장", Set.of(
+            Theme.FARM_ENVIRONMENT
+    )),
+    FACTORY("공장", Set.of(
+            Theme.FACTORY_MOTOR,
+            Theme.CONSTRUCTION_EQUIPMENT
+    )),
+    VITAL("생체", Set.of(
+            Theme.WORKER,
+            Theme.VOICE,
+            Theme.MOVEMENT,
+            Theme.BIOMETRIC_DATA
+    )),
+    LIFE_AND_VIDEO("생활/영상", Set.of(
+            Theme.ACTIVITY_VIDEO
+    )),
+    ENERGY("에너지", Set.of(
+            Theme.SOLAR,
+            Theme.ELECTRIC_POWER
+    )),
+    ENVIRONMENT("환경", Set.of(
+            Theme.OUTDOOR_STANDBY
+    )),
+    CITY("도시", Set.of(
+            Theme.VISITOR
+    )),
+    OPEN_DATA("오픈데이터", Set.of(
+            Theme.TRAFFIC,
+            Theme.CALENDAR
+    ));
 
     private final String name;
+    private final Set<Theme> themes;
 
-    Catalog(String name) {
+    Catalog(String name, Set<Theme> themes) {
         this.name = name;
+        this.themes = themes;
     }
 
     /**
@@ -35,6 +63,21 @@ public enum Catalog {
                 .filter(catalog -> catalog.matchName(name))
                 .findFirst()
                 .orElseThrow(() -> new CannotFindMatchCatalogException(name));
+    }
+
+    /**
+     * 주제 이름을 찾아 리턴합니다.
+     *
+     * @param name 찾을 주제 이름
+     * @return 찾은 주제
+     *
+     * @throws CannotFindMatchThemeException 주제 이름으로 일치하는 주제를 찾지 못한 경우
+     */
+    public Theme findThemeByName(String name) {
+        return this.themes.stream()
+                .filter(theme -> theme.matchName(name))
+                .findFirst()
+                .orElseThrow(() -> new CannotFindMatchThemeException(name));
     }
 
     private boolean matchName(String name) {

--- a/src/main/java/kr/co/automl/domain/metadata/Theme.java
+++ b/src/main/java/kr/co/automl/domain/metadata/Theme.java
@@ -1,6 +1,6 @@
 package kr.co.automl.domain.metadata;
 
-import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeTaxonomyException;
+import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeException;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -8,10 +8,10 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * 주제 분류
+ * 주제
  */
 @Getter(AccessLevel.PACKAGE)
-public enum ThemeTaxonomy {
+public enum Theme {
 
     FARM_SITUATION("농장 상황"),
     FACTORY_MOTOR("공장모터"),
@@ -28,15 +28,15 @@ public enum ThemeTaxonomy {
 
     private final String name;
 
-    ThemeTaxonomy(String name) {
+    Theme(String name) {
         this.name = name;
     }
 
-    public static ThemeTaxonomy of(String name) {
+    public static Theme of(String name) {
         return Arrays.stream(values())
                 .filter(it -> it.matchName(name))
                 .findFirst()
-                .orElseThrow(CannotFindMatchThemeTaxonomyException::new);
+                .orElseThrow(CannotFindMatchThemeException::new);
     }
 
     /**

--- a/src/main/java/kr/co/automl/domain/metadata/Theme.java
+++ b/src/main/java/kr/co/automl/domain/metadata/Theme.java
@@ -55,7 +55,7 @@ public enum Theme {
      * @param name 이름
      * @return 이름이 일치할경우 true, 아닐경우 false
      */
-    private boolean matchName(String name) {
+    boolean matchName(String name) {
         return Objects.equals(this.name, name);
     }
 }

--- a/src/main/java/kr/co/automl/domain/metadata/Theme.java
+++ b/src/main/java/kr/co/automl/domain/metadata/Theme.java
@@ -13,18 +13,22 @@ import java.util.Objects;
 @Getter(AccessLevel.PACKAGE)
 public enum Theme {
 
-    FARM_SITUATION("농장 상황"),
+    AIR_QUALITY("공기질"),
+    FARM_ENVIRONMENT("농장 환경"),
     FACTORY_MOTOR("공장모터"),
     CONSTRUCTION_EQUIPMENT("건설장비"),
-    OPERATOR_BODY_TEMPERATURE("작업자 체온"),
+    WORKER("작업자"),
     VOICE("음성"),
     MOVEMENT("움직임"),
-    PULSE_WAVE("맥파"),
+    BIOMETRIC_DATA("생체 데이터"),
     ACTIVITY_VIDEO("활동영상"),
     SOLAR("태양광"),
     OUTDOOR_STANDBY("실외대기"),
     VISITOR("방문객"),
-    DOMESTIC_TRANSPORTATION("국내교통");
+    DOMESTIC_TRANSPORTATION("국내교통"),
+    ELECTRIC_POWER("전력"),
+    TRAFFIC("교통"),
+    CALENDAR("캘린더");
 
     private final String name;
 

--- a/src/main/java/kr/co/automl/domain/metadata/Theme.java
+++ b/src/main/java/kr/co/automl/domain/metadata/Theme.java
@@ -32,11 +32,18 @@ public enum Theme {
         this.name = name;
     }
 
-    public static Theme of(String name) {
+    /**
+     * 이름으로 찾은 주제를 찾아 리턴합니다.
+     * @param name 찾을 주제 이름
+     * @return 찾은 주제
+     *
+     * @throws CannotFindMatchThemeException 이름으로 주제를 찾지 못한 경우
+     */
+    public static Theme ofName(String name) {
         return Arrays.stream(values())
-                .filter(it -> it.matchName(name))
+                .filter(theme -> theme.matchName(name))
                 .findFirst()
-                .orElseThrow(CannotFindMatchThemeException::new);
+                .orElseThrow(() -> new CannotFindMatchThemeException(name));
     }
 
     /**
@@ -44,7 +51,7 @@ public enum Theme {
      * @param name 이름
      * @return 이름이 일치할경우 true, 아닐경우 false
      */
-    boolean matchName(String name) {
+    private boolean matchName(String name) {
         return Objects.equals(this.name, name);
     }
 }

--- a/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchCatalogException.java
+++ b/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchCatalogException.java
@@ -1,0 +1,8 @@
+package kr.co.automl.domain.metadata.exceptions;
+
+public class CannotFindMatchCatalogException extends RuntimeException {
+
+    public CannotFindMatchCatalogException(String name) {
+        super(String.format("일치하는 카탈로그를 찾을 수 없습니다: %s", name));
+    }
+}

--- a/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchThemeException.java
+++ b/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchThemeException.java
@@ -1,0 +1,4 @@
+package kr.co.automl.domain.metadata.exceptions;
+
+public class CannotFindMatchThemeException extends RuntimeException {
+}

--- a/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchThemeException.java
+++ b/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchThemeException.java
@@ -1,4 +1,8 @@
 package kr.co.automl.domain.metadata.exceptions;
 
 public class CannotFindMatchThemeException extends RuntimeException {
+
+    public CannotFindMatchThemeException(String name) {
+        super(String.format("일치하는 주제를 찾을 수 없습니다: %s", name));
+    }
 }

--- a/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchThemeTaxonomyException.java
+++ b/src/main/java/kr/co/automl/domain/metadata/exceptions/CannotFindMatchThemeTaxonomyException.java
@@ -1,4 +1,0 @@
-package kr.co.automl.domain.metadata.exceptions;
-
-public class CannotFindMatchThemeTaxonomyException extends RuntimeException {
-}

--- a/src/test/java/kr/co/automl/domain/metadata/CatalogTest.java
+++ b/src/test/java/kr/co/automl/domain/metadata/CatalogTest.java
@@ -1,0 +1,49 @@
+package kr.co.automl.domain.metadata;
+
+import kr.co.automl.domain.metadata.exceptions.CannotFindMatchCatalogException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CatalogTest {
+
+    @Nested
+    class ofName_메서드는 {
+
+        @Nested
+        class 존재하는_이름이_주어질경우 {
+
+            @ParameterizedTest
+            @ValueSource(strings = {
+                    "대기 환경",
+                    "농장",
+                    "공장",
+                    "생체",
+                    "생활/영상",
+                    "에너지",
+                    "환경",
+                    "도시",
+                    "오픈데이터"
+            })
+            void 카탈로그를_리턴한다(String existName) {
+                Catalog catalog = Catalog.ofName(existName);
+                assertThat(catalog).isInstanceOf(Catalog.class);
+            }
+        }
+
+        @Nested
+        class 존재하지_않는_이름이_주어질경우 {
+
+            @Test
+            void CannotFindMatchCatalogException을_던진다() {
+                assertThatThrownBy(() -> Catalog.ofName("xxx"))
+                        .isInstanceOf(CannotFindMatchCatalogException.class)
+                        .hasMessage("일치하는 카탈로그를 찾을 수 없습니다: xxx");
+            }
+        }
+    }
+}

--- a/src/test/java/kr/co/automl/domain/metadata/CatalogTest.java
+++ b/src/test/java/kr/co/automl/domain/metadata/CatalogTest.java
@@ -1,6 +1,7 @@
 package kr.co.automl.domain.metadata;
 
 import kr.co.automl.domain.metadata.exceptions.CannotFindMatchCatalogException;
+import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,6 +44,35 @@ class CatalogTest {
                 assertThatThrownBy(() -> Catalog.ofName("xxx"))
                         .isInstanceOf(CannotFindMatchCatalogException.class)
                         .hasMessage("일치하는 카탈로그를 찾을 수 없습니다: xxx");
+            }
+        }
+    }
+
+    @Nested
+    class findThemeByName_메서드는 {
+
+        @Nested
+        class 존재하는_주제이름이_주어질경우 {
+
+            @Test
+            void 찾은_주제를_리턴한다() {
+                Catalog catalog = Catalog.CITY;
+                Theme theme = catalog.findThemeByName("방문객");
+
+                assertThat(theme).isEqualTo(Theme.VISITOR);
+            }
+        }
+
+        @Nested
+        class 존재하지않는_주제이름이_주어질경우 {
+
+            @Test
+            void CannotFindMatchThemeException을_던진다() {
+                Catalog catalog = Catalog.CITY;
+
+                assertThatThrownBy(() -> catalog.findThemeByName("xxx"))
+                        .isInstanceOf(CannotFindMatchThemeException.class)
+                        .hasMessage("일치하는 주제를 찾을 수 없습니다: xxx");
             }
         }
     }

--- a/src/test/java/kr/co/automl/domain/metadata/ThemeTest.java
+++ b/src/test/java/kr/co/automl/domain/metadata/ThemeTest.java
@@ -4,7 +4,6 @@ import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ThemeTest {
 
     @Nested
-    class of_메서드는 {
+    class ofName_메서드는 {
 
         @Nested
         class 존재하는_주제_이름이_주어질경우 {
@@ -34,7 +33,7 @@ class ThemeTest {
                     "국내교통"
             })
             void 찾은_주제를_리턴한다(String existName) {
-                assertThat(Theme.of(existName))
+                assertThat(Theme.ofName(existName))
                         .isInstanceOf(Theme.class);
             }
         }
@@ -44,38 +43,11 @@ class ThemeTest {
 
             @Test
             void CannotFindMatchThemeException을_던진다() {
-                assertThatThrownBy(() -> Theme.of("xxx"))
-                        .isInstanceOf(CannotFindMatchThemeException.class);
+                assertThatThrownBy(() -> Theme.ofName("xxx"))
+                        .isInstanceOf(CannotFindMatchThemeException.class)
+                        .hasMessage("일치하는 주제를 찾을 수 없습니다: xxx");
             }
 
         }
-    }
-
-    @Nested
-    class matchName_메서드는 {
-
-        @Nested
-        class 일치하는_이름이_주어진경우 {
-
-            @ParameterizedTest
-            @EnumSource(Theme.class)
-            void true를_리턴한다(Theme theme) {
-                String name = theme.getName();
-                assertThat(theme.matchName(name)).isTrue();
-            }
-
-        }
-
-        @Nested
-        class 일치하지않는_이름이_주어진경우 {
-
-            @ParameterizedTest
-            @EnumSource(Theme.class)
-            void false를_리턴한다(Theme theme) {
-                assertThat(theme.matchName("xxx")).isFalse();
-            }
-
-        }
-
     }
 }

--- a/src/test/java/kr/co/automl/domain/metadata/ThemeTest.java
+++ b/src/test/java/kr/co/automl/domain/metadata/ThemeTest.java
@@ -19,18 +19,21 @@ class ThemeTest {
 
             @ParameterizedTest
             @ValueSource(strings = {
-                    "농장 상황",
+                    "공기질",
+                    "농장 환경",
                     "공장모터",
                     "건설장비",
-                    "작업자 체온",
+                    "작업자",
                     "음성",
                     "움직임",
-                    "맥파",
+                    "생체 데이터",
                     "활동영상",
                     "태양광",
+                    "전력",
                     "실외대기",
                     "방문객",
-                    "국내교통"
+                    "교통",
+                    "캘린더"
             })
             void 찾은_주제를_리턴한다(String existName) {
                 assertThat(Theme.ofName(existName))

--- a/src/test/java/kr/co/automl/domain/metadata/ThemeTest.java
+++ b/src/test/java/kr/co/automl/domain/metadata/ThemeTest.java
@@ -1,6 +1,6 @@
 package kr.co.automl.domain.metadata;
 
-import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeTaxonomyException;
+import kr.co.automl.domain.metadata.exceptions.CannotFindMatchThemeException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,13 +10,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class ThemeTaxonomyTest {
+class ThemeTest {
 
     @Nested
     class of_메서드는 {
 
         @Nested
-        class 존재하는_주제분류_이름이_주어질경우 {
+        class 존재하는_주제_이름이_주어질경우 {
 
             @ParameterizedTest
             @ValueSource(strings = {
@@ -33,19 +33,19 @@ class ThemeTaxonomyTest {
                     "방문객",
                     "국내교통"
             })
-            void 주제분류를_리턴한다(String name) {
-                assertThat(ThemeTaxonomy.of(name))
-                        .isInstanceOf(ThemeTaxonomy.class);
+            void 찾은_주제를_리턴한다(String existName) {
+                assertThat(Theme.of(existName))
+                        .isInstanceOf(Theme.class);
             }
         }
 
         @Nested
-        class 존재하지않는_주제분류_이름이_주어질경우 {
+        class 존재하지않는_주제_이름이_주어질경우 {
 
             @Test
-            void CannotFindMatchThemeTaxonomyException을_던진다() {
-                assertThatThrownBy(() -> ThemeTaxonomy.of("xxx"))
-                        .isInstanceOf(CannotFindMatchThemeTaxonomyException.class);
+            void CannotFindMatchThemeException을_던진다() {
+                assertThatThrownBy(() -> Theme.of("xxx"))
+                        .isInstanceOf(CannotFindMatchThemeException.class);
             }
 
         }
@@ -58,10 +58,10 @@ class ThemeTaxonomyTest {
         class 일치하는_이름이_주어진경우 {
 
             @ParameterizedTest
-            @EnumSource(ThemeTaxonomy.class)
-            void true를_리턴한다(ThemeTaxonomy themeTaxonomy) {
-                String name = themeTaxonomy.getName();
-                assertThat(themeTaxonomy.matchName(name)).isTrue();
+            @EnumSource(Theme.class)
+            void true를_리턴한다(Theme theme) {
+                String name = theme.getName();
+                assertThat(theme.matchName(name)).isTrue();
             }
 
         }
@@ -70,9 +70,9 @@ class ThemeTaxonomyTest {
         class 일치하지않는_이름이_주어진경우 {
 
             @ParameterizedTest
-            @EnumSource(ThemeTaxonomy.class)
-            void false를_리턴한다(ThemeTaxonomy themeTaxonomy) {
-                assertThat(themeTaxonomy.matchName("xxx")).isFalse();
+            @EnumSource(Theme.class)
+            void false를_리턴한다(Theme theme) {
+                assertThat(theme.matchName("xxx")).isFalse();
             }
 
         }


### PR DESCRIPTION
- feat: 카탈로그 상수 추가
- refactor(rename): 주제 분류(ThemeTaxonomy)에서 주제로 이름 변경 #147
- refactor: 메서드 이름 변경 및 예외 메시지와 Javadoc 추가
- feat: 변경된 주제 값으로 업데이트
- feat: 카탈로그에 주제 목록 추가

### 주요 변경사항
- 주제 분류(ThemeTaxonomy)에서 주제(Theme)로 이름이 변경되고, 몇몇 값들이 추가됨
- 카탈로그가 주제 목록을 필드로 가지도록 값 추가
