### PR TITLE
feat: login시 이동하는 url dashboard로 변경

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,13 +6,13 @@ import PaperBase from "./components/presentational/PaperBase";
 import NotFound from "./error/NotFound";
 import MetaDataPage from "./pages/metadata/MetaDataPage";
 import UserPage from "./pages/user/UserPage";
+import LoginPage from "./pages/LoginPage";
 
 function PageTemplate() {
   return (
     <PaperBase>
       <Routes>
         {/* PaperBase에서 props.children으로 들어간다. */}
-        <Route path="/" element={<DashBoardPage/>}/>
         <Route path="/dashboard" element={<DashBoardPage/>}/>
         <Route path="/metadata/*" element={<MetaDataPage/>}/>
         <Route path="/user/*" element={<UserPage/>}/>
@@ -26,6 +26,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/" element={<LoginPage/>}/>
         <Route path="/*" element={<PageTemplate/>}/>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/presentational/LoginCard.jsx
+++ b/frontend/src/components/presentational/LoginCard.jsx
@@ -5,8 +5,6 @@ import Typography from '@mui/material/Typography';
 import GoogleButton from 'react-google-button';
 import {Box} from "@mui/material";
 
-const GOOGLE_LOGIN_URL = '/oauth2/authorization/google';
-
 export default function LoginCard() {
   return (
     <Card sx={{
@@ -28,7 +26,7 @@ export default function LoginCard() {
           <GoogleButton
             type="light"
             label="Google로 로그인"
-            onClick={() => window.location.href = GOOGLE_LOGIN_URL}
+            onClick={() => window.location.href = '/dashboard'}
           />
         </Box>
       </CardContent>


### PR DESCRIPTION
google 로그인은 인증되지 않은 유저의 요청은 로그인 화면으로 리다이렉트
시키므로 dashboard로 이동하는 것이 큰 문제가 있지 않아 이렇게 적용함
