### PR TITLE
ci: codecov 업로드 step 제거 #305

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,6 @@ jobs:
         run: |
           ./gradlew test
 
-      - name: 커버리지 codecov에 업로드
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./app/admin-server/build/reports/jacoco/test/jacocoTestReport.xml
-
       - name: Gradle 빌드 및 소나큐브 분석 실행
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
sonarqube에서 코드 커버리지 정보도 제공하므로, codecov는 더이상 필요하지 않음

---
Close #305
